### PR TITLE
fix: tweak select component css

### DIFF
--- a/src/ui/styles/dropdown.css
+++ b/src/ui/styles/dropdown.css
@@ -61,12 +61,12 @@
 }
 
 .dropdown.chain .dropdown__single-value {
-  @apply flex flex-grow items-center text-sm font-medium;
+  @apply flex w-full flex-grow items-center text-sm font-medium;
 }
 
 .dropdown.chain .dropdown__single-value:before {
   content: '';
-  @apply ml-1 mr-2 block h-1.5 w-1.5 rounded-full;
+  @apply mr-2 block h-1.5 w-1.5 rounded-full;
 }
 
 .dropdown.chain.isConnected .dropdown__single-value:before {


### PR DESCRIPTION
@al3mart Happy to add the `Pop Network Testnet` asap to contracts ui! :)
https://github.com/paritytech/contracts-ui/pull/554

The name is a bit lengthy, maybe `Network` and `Testnet` is a bit doubled. Nevertheless as it's the full name of the chain we should use it. It looked a bit ugly when selected. You can check it out yourself in the deployed preview. This PR fixes that. Once we get this on the branch, I'm happy to merge the pr to `contracts-ui`.


https://deploy-preview-554--contracts-ui.netlify.app/?rpc=wss://rpc2.paseo.popnetwork.xyz

Before:
![Screenshot 2024-04-11 at 10 13 07](https://github.com/r0gue-io/contracts-ui/assets/839848/30ccf21d-5f15-41c8-9bde-14340a32783e)

After:
![Screenshot 2024-04-11 at 10 12 55](https://github.com/r0gue-io/contracts-ui/assets/839848/72f85df1-fd96-4fa9-a8f1-013b97a54530)

